### PR TITLE
Fixed audit_backend log not imploding array of ids

### DIFF
--- a/src/administrator/ControllerAdmin.php
+++ b/src/administrator/ControllerAdmin.php
@@ -1,22 +1,23 @@
 <?php
 
 class SwaControllerAdmin extends JControllerAdmin {
+	/**
+	 * Extends the postDeleteHook function to log which items were delted.
+	 * This is done for all classes the inherit SwaControllerAdmin.
+	 *
+	 * @param	JModelLegacy	$model	The data model object
+	 * @param	int[]|null  	$ids	The array of ids for items being deleted
+	 *
+	 * @return	void
+	 */
+	public function postDeleteHook( JModelLegacy $model, $ids = null ) {
+		parent::postDeleteHook( $model, $ids );
 
-	public function postDeleteHook( JModelLegacy $model, $id = null ) {
-		parent::postDeleteHook( $model, $id );
+		$user_name = JFactory::getUser()->name;
+		$class = get_called_class();
+		$ids = implode(', ', $ids);
 
-		JLog::add(
-			implode(
-				', ',
-				array(
-					JFactory::getUser()->name,
-					get_called_class() . '::' . 'delete',
-					'id = ' . $id,
-				)
-			),
-			JLog::INFO,
-			'com_swa.audit_backend'
-		);
+		JLog::add( "{$user_name} {$class}::delete [{$ids}]", JLog::INFO, 'com_swa.audit_backend' );
 	}
 
 }


### PR DESCRIPTION
The postDeleteHook in the base SwaControllerAdmin class thought it was receiving a single int when in fact it was receiving an array of ints. Solved my imploding the array. Also restructured the method and add docblock to reduce confusion in the future.

Fixes #113 